### PR TITLE
fix a null pointer dereference

### DIFF
--- a/savepng.c
+++ b/savepng.c
@@ -70,7 +70,6 @@ int SDL_SavePNG_RW(SDL_Surface *surface, SDL_RWops *dst, int freedst)
 	if (!dst)
 	{
 		SDL_SetError("Argument 2 to SDL_SavePNG_RW can't be NULL, expecting SDL_RWops*\n");
-		if (freedst) SDL_RWclose(dst);
 		return (ERROR);
 	}
 	if (!surface)


### PR DESCRIPTION
Thanks for writing this lib, it works well. I have actually merged it into the development version 1.13 of wesnoth. The only bug that I have noticed so far was this one, which can occur if you give it a null pointer for the RW_ops argument.
